### PR TITLE
Add missing repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
     "typed-styles",
     "flowtype"
   ],
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/lttb/typed-styles.git"
+  },
   "scripts": {
     "lint": "eslint src",
     "lint:staged": "lint-staged",


### PR DESCRIPTION
A repository url field is required in order for webjars to be created for this library.